### PR TITLE
Add additional fixtures for different Simulation setup APIs

### DIFF
--- a/pymob/sim/config.py
+++ b/pymob/sim/config.py
@@ -454,7 +454,7 @@ class Config(BaseModel):
         try:
             Simulation = getattr(self._modules["sim"], self.case_study.simulation)
         except:
-            ImportError(
+            raise ImportError(
                 f"Simulation class {self.case_study.simulation} "
                 "could not be found. Make sure the simulaton option is spelled "
                 "correctly or specify an class that exists in sim.py"

--- a/pymob/sim/config.py
+++ b/pymob/sim/config.py
@@ -308,7 +308,7 @@ class Config(BaseModel):
 
     def __init__(
         self,
-        config: Optional[Union[str, configparser.ConfigParser]],
+        config: Optional[Union[str, configparser.ConfigParser]] = None,
     ) -> None:
 
         _cfg_fp = None

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,3 +1,5 @@
+from pymob.sim.config import Config
+from pymob.simulation import SimulationBase
 from pymob.utils.store_file import prepare_casestudy
 
 def init_simulation_casestudy_api(scenario="test_scenario"):
@@ -13,4 +15,29 @@ def init_simulation_casestudy_api(scenario="test_scenario"):
     return sim
 
 def init_simulation_scripting_api(scenario="test_scenario"):
-    pass
+    config = Config()
+
+    config.case_study.name = "test_case_study"
+    config.case_study.scenario = scenario
+    config.case_study.package = "case_studies"
+    config.case_study.simulation = "Simulation"
+    config.import_casestudy_modules()
+
+    Simulation = config.import_simulation_from_case_study()
+    sim = Simulation(config)
+    sim.setup()
+
+
+def init_simulation_scripting_api_v2(scenario="test_scenario"):
+    config = Config()
+
+    config.case_study.name = "test_case_study"
+    config.case_study.scenario = scenario
+    config.case_study.package = "case_studies"
+    config.case_study.simulation = "Simulation"
+    config.import_casestudy_modules()
+
+    # and this works as well,
+    from test_case_study.sim import Simulation # type: ignore
+    sim = Simulation(config)
+    sim.setup()


### PR DESCRIPTION
This implements fixtures (and thus methods) to use the new scripting API to work with case studies along the lines of #30 