### PR TITLE
API Change: Evaluator dispatch, Feature: allow variable dimensional x_in and y0

### DIFF
--- a/case_studies/test_case_study/mod.py
+++ b/case_studies/test_case_study/mod.py
@@ -46,7 +46,7 @@ def solve(model, parameters, coordinates, data_variables):
 def solve_jax(model, parameters, coordinates, data_variables, seed=None):
     time = jnp.array(coordinates["time"])
     params = parameters["parameters"]
-    y0 = parameters["y0"]
+    y0 = [y["data"] for k, y in parameters["y0"].items()]
     ode_args = mappar(model, params, exclude=["t", "y"])
 
     result = odesolve(model, tuple(y0), time, ode_args)

--- a/case_studies/test_case_study/mod.py
+++ b/case_studies/test_case_study/mod.py
@@ -46,7 +46,7 @@ def solve(model, parameters, coordinates, data_variables):
 def solve_jax(model, parameters, coordinates, data_variables, seed=None):
     time = jnp.array(coordinates["time"])
     params = parameters["parameters"]
-    y0 = [y["data"] for k, y in parameters["y0"].items()]
+    y0 = [y for k, y in parameters["y0"].items()]
     ode_args = mappar(model, params, exclude=["t", "y"])
 
     result = odesolve(model, tuple(y0), time, ode_args)

--- a/case_studies/test_case_study/scenarios/test_scenario/settings.cfg
+++ b/case_studies/test_case_study/scenarios/test_scenario/settings.cfg
@@ -4,7 +4,7 @@ observations = simulated_noisy_data.nc
 
 [simulation]
 input_files = config.json 
-replicated = 0
+y0 = rabbits=40 wolves=9
 
 [data-structure]
 # The order of the datavariables is relevant
@@ -35,7 +35,6 @@ minimum_epsilon = 0.01
 min_eps_diff = 0.001
 max_nr_populations = 50
 sampler = SingleCoreSampler
-database_path = pyabc_database.db
 
 
 [inference.pyabc.redis]

--- a/case_studies/test_case_study/scenarios/test_scenario_scripting_api/settings.cfg
+++ b/case_studies/test_case_study/scenarios/test_scenario_scripting_api/settings.cfg
@@ -64,6 +64,11 @@ chains = 1
 draws = 2000
 warmup = 1000
 thinning = 1
+nuts_draws = 2000
+nuts_step_size = 0.8
+nuts_max_tree_depth = 10
+nuts_target_accept_prob = 0.8
+nuts_dense_mass = True
 svi_iterations = 10000
 svi_learning_rate = 0.0001
 

--- a/case_studies/test_case_study/scenarios/test_scenario_scripting_api/settings.cfg
+++ b/case_studies/test_case_study/scenarios/test_scenario_scripting_api/settings.cfg
@@ -12,7 +12,7 @@ y0 =
 x_in = 
 input_files = 
 n_ode_states = -1
-modeltype = stochastic
+modeltype = deterministic
 seed = 1
 
 [data-structure]

--- a/case_studies/test_case_study/scenarios/test_scenario_scripting_api/settings.cfg
+++ b/case_studies/test_case_study/scenarios/test_scenario_scripting_api/settings.cfg
@@ -17,7 +17,7 @@ modeltype = stochastic
 seed = 1
 
 [data-structure]
-wolves = dimensions=[time] min=0.0 max=nan
+wolves = dimensions=[time] min=0.0 max=nan observed=True
 
 [inference]
 objective_function = total_average

--- a/case_studies/test_case_study/scenarios/test_scenario_scripting_api/settings.cfg
+++ b/case_studies/test_case_study/scenarios/test_scenario_scripting_api/settings.cfg
@@ -12,7 +12,6 @@ y0 =
 x_in = 
 input_files = 
 n_ode_states = -1
-replicated = False
 modeltype = stochastic
 seed = 1
 

--- a/case_studies/test_case_study/scenarios/test_scenario_scripting_api/test_settings.cfg
+++ b/case_studies/test_case_study/scenarios/test_scenario_scripting_api/test_settings.cfg
@@ -8,6 +8,7 @@ observations = simulated_data.nc
 logging = DEBUG
 
 [simulation]
+model = lotka_volterra
 y0 = 
 x_in = 
 input_files = 

--- a/case_studies/test_case_study/scenarios/test_scenario_scripting_api/test_settings.cfg
+++ b/case_studies/test_case_study/scenarios/test_scenario_scripting_api/test_settings.cfg
@@ -66,6 +66,11 @@ chains = 1
 draws = 2000
 warmup = 1000
 thinning = 1
+nuts_draws = 2000
+nuts_step_size = 0.8
+nuts_max_tree_depth = 10
+nuts_target_accept_prob = 0.8
+nuts_dense_mass = True
 svi_iterations = 10000
 svi_learning_rate = 0.0001
 

--- a/case_studies/test_case_study/scenarios/test_scenario_scripting_api/test_settings.cfg
+++ b/case_studies/test_case_study/scenarios/test_scenario_scripting_api/test_settings.cfg
@@ -13,7 +13,7 @@ y0 =
 x_in = 
 input_files = 
 n_ode_states = -1
-modeltype = stochastic
+modeltype = deterministic
 seed = 1
 
 [data-structure]

--- a/case_studies/test_case_study/scenarios/test_scenario_scripting_api/test_settings.cfg
+++ b/case_studies/test_case_study/scenarios/test_scenario_scripting_api/test_settings.cfg
@@ -17,8 +17,8 @@ modeltype = stochastic
 seed = 1
 
 [data-structure]
-rabbits = dimensions=[time] min=7.063576698303223 max=79.80426788330078
-wolves = dimensions=[time] min=8.627415657043457 max=54.88554382324219
+rabbits = dimensions=[time] min=7.063576698303223 max=79.80426788330078 observed=True
+wolves = dimensions=[time] min=8.627415657043457 max=54.88554382324219 observed=True
 
 [inference]
 objective_function = total_average

--- a/case_studies/test_case_study/scenarios/test_scenario_scripting_api/test_settings.cfg
+++ b/case_studies/test_case_study/scenarios/test_scenario_scripting_api/test_settings.cfg
@@ -12,7 +12,6 @@ y0 =
 x_in = 
 input_files = 
 n_ode_states = -1
-replicated = False
 modeltype = stochastic
 seed = 1
 

--- a/case_studies/test_case_study/sim.py
+++ b/case_studies/test_case_study/sim.py
@@ -1,6 +1,7 @@
 import numpy as np
 import xarray as xr
 from pymob.simulation import SimulationBase
+from pymob.solvers.diffrax import JaxSolver
 from test_case_study.mod import lotka_volterra, solve, solve_jax
 from test_case_study.plot import plot_trajectory
 from test_case_study import prob
@@ -17,16 +18,12 @@ class Simulation(SimulationBase):
             gamma = 0.3,  # Predator reproduction rate
             delta = 0.01,  # Predator death rate
         )
-        if self.config.simulation.replicated:
-            self.model_parameters["y0"] = self.RNG.integers(1, 50, size=(10, 2))
-        else:
-            self.model_parameters["y0"] = np.array([40, 9])  # initial population of prey and predator
-
         
         self.observations = xr.load_dataset(input[1])
         self.observations["wolves"] = self.observations["wolves"] + 1e-8
         self.observations["rabbits"] = self.observations["rabbits"] + 1e-8
 
+        self.model_parameters["y0"] = self.parse_input("y0", drop_dims=["time"])
         
     @staticmethod
     def parameterize(free_parameters: dict, model_parameters):

--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -1,0 +1,7 @@
+pymob
+=====
+
+.. toctree::
+   :maxdepth: 4
+
+   pymob

--- a/docs/source/api/pymob.rst
+++ b/docs/source/api/pymob.rst
@@ -9,6 +9,7 @@ Subpackages
 
    pymob.inference
    pymob.sim
+   pymob.solvers
    pymob.utils
 
 Submodules

--- a/docs/source/api/pymob.solvers.rst
+++ b/docs/source/api/pymob.solvers.rst
@@ -1,0 +1,45 @@
+pymob.solvers package
+=====================
+
+Submodules
+----------
+
+pymob.solvers.analytic module
+-----------------------------
+
+.. automodule:: pymob.solvers.analytic
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pymob.solvers.base module
+-------------------------
+
+.. automodule:: pymob.solvers.base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pymob.solvers.diffrax module
+----------------------------
+
+.. automodule:: pymob.solvers.diffrax
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+pymob.solvers.scipy module
+--------------------------
+
+.. automodule:: pymob.solvers.scipy
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: pymob.solvers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/user_guide/diagnosing_problems.md
+++ b/docs/source/user_guide/diagnosing_problems.md
@@ -7,8 +7,11 @@ and fix such problems.
 
 ## NaN likelihoods with `JaxSolver`
 
+The {class}`pymob.solvers.diffrax.JaxSolver` is highly efficient, but can be difficult to use.
+
++ In the {meth}`pymob.simulation.SimulationBase.dispatch_constructor` set `throw_exception=True` to make the solver fail if it runs into nans. This will make the solver fail loudly if there are problems. The default is that the solver returns infinities if there are problems. Numpyro can handle infinities in the probability functions consider the parameters impossible which can lead to severely biased estimates.
 + First make sure this problem is not related to the choice and the parameterization
-  of the solver. In the {meth}`pymob.simulation.SimulationBase.dispatch_constructor` Try increasing `max_steps`, 
+  of the solver. In the {meth}`pymob.simulation.SimulationBase.dispatch_constructor`, try increasing `max_steps`, 
 
 
 

--- a/docs/source/user_guide/diagnosing_problems.md
+++ b/docs/source/user_guide/diagnosing_problems.md
@@ -1,0 +1,26 @@
+# Diagnosing problems in models
+
+For structural problems `pymob` should offer constructive error messages, before
+problems occurr. Still during parameter inference and optimization many problems
+can ocurr, the below is an unsorted list of typical problems and ways to diagnose
+and fix such problems.
+
+## NaN likelihoods with `JaxSolver`
+
++ First make sure this problem is not related to the choice and the parameterization
+  of the solver. In the {meth}`pymob.simulation.SimulationBase.dispatch_constructor` Try increasing `max_steps`, 
+
+
+
+
+
+
+
+
+
+
+
+
+
+## Further reference
+

--- a/docs/source/user_guide/index.md
+++ b/docs/source/user_guide/index.md
@@ -18,4 +18,5 @@ quickstart
 case_studies
 simulation
 parameter_inference
+diagnosing_problems
 ```

--- a/pymob/__init__.py
+++ b/pymob/__init__.py
@@ -1,6 +1,7 @@
 from . import inference
 from . import sim
 from . import utils
+from . import solvers
 
 __version__ = "0.4.1"
 

--- a/pymob/inference/numpyro_backend.py
+++ b/pymob/inference/numpyro_backend.py
@@ -231,7 +231,7 @@ class NumpyroBackend:
         """
         obs = self.simulation.observations \
             .transpose(*self.simulation.dimensions)
-        data_vars = self.config.data_structure.data_variables + self.extra_vars
+        data_vars = self.config.data_structure.observed_data_variables + self.extra_vars
 
         masks = {}
         observations = {}
@@ -624,12 +624,12 @@ class NumpyroBackend:
         elif kernel == "nuts":
             sampler = infer.NUTS(
                 model, 
-                dense_mass=True, 
-                step_size=0.01,
+                dense_mass=self.config.inference_numpyro.nuts_dense_mass, 
+                step_size=self.config.inference_numpyro.nuts_step_size,
                 adapt_mass_matrix=True,
                 adapt_step_size=True,
-                max_tree_depth=10,
-                target_accept_prob=0.8,
+                max_tree_depth=self.config.inference_numpyro.nuts_max_tree_depth,
+                target_accept_prob=self.config.inference_numpyro.nuts_target_accept_prob,
                 init_strategy=self.init_strategy
             )
         else:

--- a/pymob/inference/numpyro_backend.py
+++ b/pymob/inference/numpyro_backend.py
@@ -229,8 +229,8 @@ class NumpyroBackend:
         Tuple[Dict,Dict]
             Dictionaries of observations (data) and masks (missing values)
         """
-        obs = self.simulation.observations \
-            .transpose(*self.simulation.dimensions)
+        obs = self.simulation.observations #\
+            # .transpose(*self.simulation.dimensions)
         data_vars = self.config.data_structure.observed_data_variables + self.extra_vars
 
         masks = {}

--- a/pymob/sim/config.py
+++ b/pymob/sim/config.py
@@ -414,7 +414,7 @@ class Simulation(BaseModel):
     # data_variables: OptionListStr = []
     n_ode_states: int = -1
     batch_dimension: Optional[str] = None
-    modeltype: Literal["stochastic", "deterministic"] = "stochastic"
+    modeltype: Literal["stochastic", "deterministic"] = "deterministic"
     solver_post_processing: Optional[str] = Field(default=None, validate_default=True)
     seed: Annotated[int, to_str] = 1
 

--- a/pymob/sim/config.py
+++ b/pymob/sim/config.py
@@ -47,13 +47,6 @@ class ArrayParam(BaseModel):
     prior: Optional[str] = None
     free: bool = True
 
-class DataArrayDict(TypedDict):
-    dims: Tuple
-    attrs: Dict
-    data: List
-    coords: Dict[str, List]
-    name: str
-
 class ModelParameterDict(TypedDict):
     parameters: Dict[str, float|str|int]
     y0: xr.Dataset

--- a/pymob/sim/config.py
+++ b/pymob/sim/config.py
@@ -434,6 +434,9 @@ class Datastructure(BaseModel):
         deleted_var = self.__pydantic_extra__.pop(key)
         print(f"Deleted '{key}' DataVariable({deleted_var}).")
 
+    def __getitem__(self, key):
+        return self.__pydantic_extra__[key]
+
     @property
     def data_variables(self) -> List[str]:
         return [k for k in self.__pydantic_extra__.keys()]

--- a/pymob/sim/config.py
+++ b/pymob/sim/config.py
@@ -633,17 +633,30 @@ class Numpyro(BaseModel):
     user_defined_probability_model: Optional[str] = None
     user_defined_preprocessing: Optional[str] = None
     gaussian_base_distribution: bool = False
+    
+    # inference arguments
     kernel: str = "nuts"
     init_strategy: str = "init_to_uniform"
+     
+    # mcmc parameters
     chains: Annotated[int, to_str] = 1
     draws: Annotated[int, to_str] = 2000
     warmup: Annotated[int, to_str] = 1000
     thinning: Annotated[int, to_str] = 1
-    svi_iterations: Annotated[int, to_str] = 10_000
-    svi_learning_rate: Annotated[float, to_str] = 0.0001
+    
+    # nuts arguments
+    nuts_draws: Annotated[int, to_str] = 2000
+    nuts_step_size: Annotated[float, to_str] = 0.8
+    nuts_max_tree_depth: Annotated[int, to_str] = 10
+    nuts_target_accept_prob: Annotated[float, to_str] = 0.8
+    nuts_dense_mass: Annotated[bool, to_str] = True
+
+    # sa parameters
     sa_adapt_state_size: Optional[int] = None
 
-
+    # svi parameters
+    svi_iterations: Annotated[int, to_str] = 10_000
+    svi_learning_rate: Annotated[float, to_str] = 0.0001
 
 class Config(BaseModel):
     """Configuration manager for pymob."""

--- a/pymob/sim/config.py
+++ b/pymob/sim/config.py
@@ -9,12 +9,13 @@ import importlib
 import logging
 import json
 import multiprocessing as mp
-from typing import List, Optional, Union, Dict, Literal, Callable
+from typing import List, Optional, Union, Dict, Literal, Callable, Tuple, TypedDict
 from typing_extensions import Annotated
 from types import ModuleType
 import tempfile
 
 import numpy as np
+import xarray as xr
 from numpy.typing import ArrayLike
 
 from pydantic import (
@@ -45,6 +46,18 @@ class ArrayParam(BaseModel):
     step: Optional[List[float]] = None
     prior: Optional[str] = None
     free: bool = True
+
+class DataArrayDict(TypedDict):
+    dims: Tuple
+    attrs: Dict
+    data: List
+    coords: Dict[str, List]
+    name: str
+
+class ModelParameterDict(TypedDict):
+    parameters: Dict[str, float|str|int]
+    y0: xr.Dataset
+    x_in: xr.Dataset
 
 class DataVariable(BaseModel):
     """Describe a data variable
@@ -407,7 +420,7 @@ class Simulation(BaseModel):
     input_files: OptionListStr = []
     # data_variables: OptionListStr = []
     n_ode_states: int = -1
-    replicated: bool = False
+    batch_dimension: Optional[str] = None
     modeltype: Literal["stochastic", "deterministic"] = "stochastic"
     solver_post_processing: Optional[str] = Field(default=None, validate_default=True)
     seed: Annotated[int, to_str] = 1

--- a/pymob/sim/solvetools.py
+++ b/pymob/sim/solvetools.py
@@ -1,34 +1,11 @@
 from typing import Literal
-import inspect
 import xarray as xr
-from scipy.integrate import solve_ivp
-
-class SolverBase:
-    """
-    The idea of creating a solver as a class is that it is easier
-    to pass on important arguments of the simulation relevant to the 
-    Solver. Therefore a solver can access all attributes of an Evaluator
-    """
-    def __call__(self, **kwargs):
-        return self.solve(**kwargs)
-    
-    @staticmethod
-    def solve():
-        raise NotImplementedError("Solver must implement a solve method.")
 
 
-def mappar(func, parameters, exclude=[], to:Literal["tuple","dict"]="tuple"):
-    func_signature = inspect.signature(func).parameters.keys()
-    model_param_signature = [p for p in func_signature if p not in exclude]
-    if to == "tuple":
-        model_args = [parameters.get(k) for k in model_param_signature]
-        model_args = tuple(model_args)
-    elif to == "dict":
-        model_args = {k: parameters.get(k) for k in model_param_signature}
-    else:
-        raise NotImplementedError(f"'to={to}' is not implemented for 'mappar'")
-
-    return model_args
+# legacy imports. These functions are now included in pymob.solvers.base
+from pymob.solvers.base import mappar
+from pymob.solvers.analytic import solve_analytic_1d
+from pymob.solvers.scipy import solve_ivp_1d
 
 
 def create_interpolation(
@@ -91,70 +68,3 @@ def create_interpolation(
     return x_in_interpolated
 
 
-
-def solve_analytic_1d(model, parameters, dimensions, coordinates, data_variables, seed=None):
-    """Solves an anlytic function for all coordinates in the first data 
-    dimension of the model
-
-    - parameters: define the model
-    - y0: set the initial values of the ODE states
-    - coordinates: are needed to know over which values to integrate
-    - seed: In case stochastic processes take place inside the model this is necessary
-    
-    In order to make things explicit, all information which is needed by the
-    model needs to be specified in the function signature. 
-    This also makes the solvers functionally oriented, a feature that helps the
-    usability of models accross inference frameworks. Where functions should not
-    have side effects.
-
-    Additionally, passing arguments via the signature makes it easier to write
-    up models in a casual way and only later embed them into more regulated
-    structures such as pymob
-
-    """
-    
-    model_args = mappar(
-        model, 
-        parameters["parameters"], 
-        exclude=["t", "x"] + dimensions,
-        to="dict"
-    )
-    
-    x = coordinates[dimensions[0]]
-
-    model_results = []
-    results = model(x, **model_args)
-    model_results.append(results)
-    
-    return {data_var:y for data_var, y in zip(data_variables, model_results)}
-
-
-def solve_ivp_1d(model, parameters, coordinates, data_variables):
-    """Initial value problems always need the same number of recurrent arguments
-
-    - parameters: define the model
-    - y0: set the initial values of the ODE states
-    - coordinates: are needed to know over which values to integrate
-    - seed: In case stochastic processes take place inside the model this is necessary
-    
-    In order to make things explicit, all information which is needed by the
-    model needs to be specified in the function signature. 
-    This also makes the solvers functionally oriented, a feature that helps the
-    usability of models accross inference frameworks. Where functions should not
-    have side effects.
-
-    Additionally, passing arguments via the signature makes it easier to write
-    up models in a casual way and only later embed them into more regulated
-    structures such as pymob
-
-    """
-    odeargs = mappar(model, parameters["parameters"], exclude=["t", "y"])
-    t = coordinates["time"]
-    results = solve_ivp(
-        fun=model,
-        y0=parameters["y0"],
-        t_span=(t[0], t[-1]),
-        t_eval=t,
-        args=odeargs,
-    )
-    return {data_var:y for data_var, y in zip(data_variables, results.y)}

--- a/pymob/sim/solvetools.py
+++ b/pymob/sim/solvetools.py
@@ -3,7 +3,7 @@ import xarray as xr
 
 
 # legacy imports. These functions are now included in pymob.solvers.base
-from pymob.solvers.base import mappar, create_interpolation
+from pymob.solvers.base import mappar, smoothed_interpolation, jump_interpolation, rect_interpolation
 from pymob.solvers.analytic import solve_analytic_1d
 from pymob.solvers.scipy import solve_ivp_1d
 

--- a/pymob/sim/solvetools.py
+++ b/pymob/sim/solvetools.py
@@ -3,68 +3,8 @@ import xarray as xr
 
 
 # legacy imports. These functions are now included in pymob.solvers.base
-from pymob.solvers.base import mappar
+from pymob.solvers.base import mappar, create_interpolation
 from pymob.solvers.analytic import solve_analytic_1d
 from pymob.solvers.scipy import solve_ivp_1d
-
-
-def create_interpolation(
-        x_in: xr.Dataset, 
-        y: str, 
-        x: str="time", 
-        factor: float=1e-4, 
-        interpolation: Literal["fill-forward", "linear"] = "fill-forward",
-    ) -> xr.Dataset:
-    """Make the interpolation safe by adding a coordinate just before each 
-    x-value (except the first vaue). The distance between the new and the next
-    point are calculated as a fraction of the previous distance between
-    neighboring points. The corresponding y-values are first set to NaN and then
-    interpolated based on the interpolation method.
-
-    Parameters
-    ----------
-    x_in : xr.Dataset
-        The input dataset which contains a coordinate (x) and a data variable
-        (y)
-    x : str, optional
-        The name of the x coordinate, by default "time"
-    factor : float, optional
-        The distance between the newly added points and the following existing
-        points on the x-scale, by default 1e-4
-    interpolation : Literal["fill-forward", "linear"], optional
-        The interpolation method. In addition to 'fill-forward' and 'linear',
-        any method give in `xr.interpolate_na` can be chosen, by default
-        "fill-forward"
-
-    Returns
-    -------
-    xr.Dataset
-        The interpolated dataset
-    """
-    xs = x_in.coords[x]
-
-    # calculate x values that are located just a little bit smaller than the xs
-    # where "just a little bit" is defined by the distance to the previous x
-    # and a factor. This way the scale of the observations should not matter
-    # and even very differently sized x-steps should be interpolated correctly
-    fraction_before_xs = (
-        xs.isel({x:range(1, len(xs))}).values
-        - xs.diff(dim=x) * factor
-    )
-
-    # create a sorted time vector
-    xs = sorted([*fraction_before_xs.values, *xs.values])
-
-    # add new time indices with NaN values 
-    x_in_reindexed = x_in.reindex({x:xs})
-
-    if interpolation == "fill-forward":
-        # then fill nan values with the previous value (forward-fill)
-        x_in_interpolated = x_in_reindexed.ffill(dim=x, limit=1)
-
-    else:
-        x_in_interpolated = x_in_reindexed.interpolate_na(dim=x, method="linear")
-
-    return x_in_interpolated
 
 

--- a/pymob/simulation.py
+++ b/pymob/simulation.py
@@ -433,6 +433,15 @@ class SimulationBase:
         mask = data[batch_dim].isin(self.coordinates[batch_dim])
         return data.where(mask, drop=True)
 
+    @property
+    def coordinates_input_vars(self):
+        input_vars = ["x_in", "y0"]
+        return {
+            k: {ck: cv.values for ck, cv in v.coords.items()} 
+            for k, v in self.model_parameters.items() 
+            if k in input_vars
+        }
+
 
     def dispatch_constructor(self, **evaluator_kwargs):
         """Construct the dispatcher and pass everything to the evaluator that is 
@@ -476,12 +485,7 @@ class SimulationBase:
 
         stochastic = self.config.simulation.modeltype
             
-        input_vars = ["x_in", "y0"]
-        coordinates_input_vars={
-            k: {ck: cv.values for ck, cv in v.coords.items()} 
-            for k, v in self.model_parameters.items() 
-            if k in input_vars
-        }
+
 
         self.evaluator = Evaluator(
             model=model,
@@ -493,7 +497,7 @@ class SimulationBase:
             data_structure=self.data_structure,
             data_variables=self.data_variables,
             coordinates=self.coordinates,
-            coordinates_input_vars=coordinates_input_vars,
+            coordinates_input_vars=self.coordinates_input_vars,
             # TODO: pass the whole simulation settings section
             stochastic=True if stochastic == "stochastic" else False,
             indices=self.indices,

--- a/pymob/simulation.py
+++ b/pymob/simulation.py
@@ -4,7 +4,7 @@ import copy
 import inspect
 import warnings
 import importlib
-from typing import Optional, List, Union, Literal, Any, LiteralString, Tuple
+from typing import Optional, List, Union, Literal, Any, Tuple
 from types import ModuleType
 import configparser
 from functools import partial

--- a/pymob/simulation.py
+++ b/pymob/simulation.py
@@ -476,6 +476,13 @@ class SimulationBase:
 
         stochastic = self.config.simulation.modeltype
             
+        input_vars = ["x_in", "y0"]
+        coordinates_input_vars={
+            k: {ck: cv.values for ck, cv in v.coords.items()} 
+            for k, v in self.model_parameters.items() 
+            if k in input_vars
+        }
+
         self.evaluator = Evaluator(
             model=model,
             solver=solver,
@@ -486,6 +493,7 @@ class SimulationBase:
             data_structure=self.data_structure,
             data_variables=self.data_variables,
             coordinates=self.coordinates,
+            coordinates_input_vars=coordinates_input_vars,
             # TODO: pass the whole simulation settings section
             stochastic=True if stochastic == "stochastic" else False,
             indices=self.indices,

--- a/pymob/simulation.py
+++ b/pymob/simulation.py
@@ -14,6 +14,7 @@ from multiprocessing.pool import ThreadPool, Pool
 import re
 
 import numpy as np
+from numpy.typing import ArrayLike
 import xarray as xr
 import dpath as dp
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
@@ -24,7 +25,7 @@ from pymob.utils.errors import errormsg, import_optional_dependency
 from pymob.utils.store_file import scenario_file, parse_config_section
 from pymob.sim.evaluator import Evaluator, create_dataset_from_dict, create_dataset_from_numpy
 from pymob.sim.base import stack_variables
-from pymob.sim.config import Config, FloatParam, ArrayParam, ParameterDict, DataVariable, DataArrayDict
+from pymob.sim.config import Config, FloatParam, ArrayParam, ParameterDict, DataVariable
 
 config_deprecation = "Direct access of config options will be deprecated. Use `Simulation.config.OPTION` API instead"
 MODULES = ["sim", "mod", "prob", "data", "plot"]
@@ -412,11 +413,10 @@ class SimulationBase:
         return n_ode_states
         
     @staticmethod
-    def validate_model_input(model_input) -> DataArrayDict:
+    def validate_model_input(model_input) -> Dict[str, ArrayLike]:
         if isinstance(model_input, xr.Dataset):
             model_input = {
-                k: {"data": dv.to_dict()["data"], "coords": dv.to_dict()["coords"]} 
-                for k, dv in model_input.data_vars.items()
+                k: dv.values for k, dv in model_input.data_vars.items()
             }
             return model_input # type: ignore
         

--- a/pymob/solvers/__init__.py
+++ b/pymob/solvers/__init__.py
@@ -1,0 +1,4 @@
+from . import base
+from . import analytic
+from . import diffrax
+from . import scipy

--- a/pymob/solvers/analytic.py
+++ b/pymob/solvers/analytic.py
@@ -1,0 +1,37 @@
+from pymob.solvers.base import mappar
+
+def solve_analytic_1d(model, parameters, dimensions, coordinates, data_variables, seed=None):
+    """Solves an anlytic function for all coordinates in the first data 
+    dimension of the model
+
+    - parameters: define the model
+    - y0: set the initial values of the ODE states
+    - coordinates: are needed to know over which values to integrate
+    - seed: In case stochastic processes take place inside the model this is necessary
+    
+    In order to make things explicit, all information which is needed by the
+    model needs to be specified in the function signature. 
+    This also makes the solvers functionally oriented, a feature that helps the
+    usability of models accross inference frameworks. Where functions should not
+    have side effects.
+
+    Additionally, passing arguments via the signature makes it easier to write
+    up models in a casual way and only later embed them into more regulated
+    structures such as pymob
+
+    """
+    
+    model_args = mappar(
+        model, 
+        parameters["parameters"], 
+        exclude=["t", "x"] + dimensions,
+        to="dict"
+    )
+    
+    x = coordinates[dimensions[0]]
+
+    model_results = []
+    results = model(x, **model_args)
+    model_results.append(results)
+    
+    return {data_var:y for data_var, y in zip(data_variables, model_results)}

--- a/pymob/solvers/base.py
+++ b/pymob/solvers/base.py
@@ -24,7 +24,7 @@ class SolverBase:
     batch_dimension: str = "batch_id"
 
     # fields that are computed post_init
-    x: Tuple = field(init=False)
+    x: Tuple[float] = field(init=False)
 
     def __post_init__(self, *args, **kwargs):
         object.__setattr__(self, "x", tuple(self.coordinates[self.x_dim]))

--- a/pymob/solvers/base.py
+++ b/pymob/solvers/base.py
@@ -1,5 +1,6 @@
-from typing import Literal
-from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Sequence, Literal, Tuple
+from frozendict import frozendict
+from dataclasses import dataclass, field
 import inspect
 
 @dataclass(frozen=True)
@@ -9,6 +10,25 @@ class SolverBase:
     to pass on important arguments of the simulation relevant to the 
     Solver. Therefore a solver can access all attributes of an Evaluator
     """
+    model: Callable
+    dimensions: Tuple
+    n_ode_states: int
+    coordinates: frozendict[str, Tuple]
+    data_variables: Tuple
+    is_stochastic: bool
+    solver_kwargs: frozendict = frozendict()
+    indices: frozendict[str, Tuple] = frozendict()
+    post_processing: Optional[Callable] = None
+
+    x_dim: str = "time"
+    batch_dimension: str = "batch_id"
+
+    # fields that are computed post_init
+    x: Tuple = field(init=False)
+
+    def __post_init__(self, *args, **kwargs):
+        object.__setattr__(self, "x", tuple(self.coordinates[self.x_dim]))
+
     def __call__(self, **kwargs):
         return self.solve(**kwargs)
     

--- a/pymob/solvers/base.py
+++ b/pymob/solvers/base.py
@@ -1,0 +1,30 @@
+from typing import Literal
+from dataclasses import dataclass
+import inspect
+
+@dataclass(frozen=True)
+class SolverBase:
+    """
+    The idea of creating a solver as a class is that it is easier
+    to pass on important arguments of the simulation relevant to the 
+    Solver. Therefore a solver can access all attributes of an Evaluator
+    """
+    def __call__(self, **kwargs):
+        return self.solve(**kwargs)
+    
+    def solve(self):
+        raise NotImplementedError("Solver must implement a solve method.")
+
+def mappar(func, parameters, exclude=[], to:Literal["tuple","dict"]="tuple"):
+    func_signature = inspect.signature(func).parameters.keys()
+    model_param_signature = [p for p in func_signature if p not in exclude]
+    if to == "tuple":
+        model_args = [parameters.get(k) for k in model_param_signature]
+        model_args = tuple(model_args)
+    elif to == "dict":
+        model_args = {k: parameters.get(k) for k in model_param_signature}
+    else:
+        raise NotImplementedError(f"'to={to}' is not implemented for 'mappar'")
+
+    return model_args
+

--- a/pymob/solvers/base.py
+++ b/pymob/solvers/base.py
@@ -23,9 +23,10 @@ class SolverBase:
 
     x_dim: str = "time"
     batch_dimension: str = "batch_id"
+    extra_attributes = []
 
     # fields that are computed post_init
-    x: Tuple[float] = field(init=False)
+    x: Tuple[float] = field(init=False, repr=False)
 
     def __post_init__(self, *args, **kwargs):
         x = self.coordinates[self.x_dim]
@@ -34,6 +35,13 @@ class SolverBase:
                 f"x_dim '{self.x_dim}' must be sorted in ascending order."
             )
         object.__setattr__(self, "x", x)
+
+        # set extra attributes from solver_kwargs, which are specified through
+        # the dispatch_constructor. Those don't receive post-processing
+        for key in self.extra_attributes:
+            value = self.solver_kwargs.get(key, None)
+            if value is not None:
+                object.__setattr__(self, key, value)
 
     def __call__(self, **kwargs):
         return self.solve(**kwargs)

--- a/pymob/solvers/base.py
+++ b/pymob/solvers/base.py
@@ -51,19 +51,21 @@ class SolverBase:
         return self.solve(**kwargs)
     
     def test_matching_batch_dims(self):
-        bc = self.coordinates[self.batch_dimension]
-        matching_batch_coords_if_present = [
-            v[self.batch_dimension] == bc 
-            for k, v in self.coordinates_input_vars.items() 
-            if self.batch_dimension in v
-        ]
+        bc = self.coordinates.get(self.batch_dimension, None)
 
-        if not all(matching_batch_coords_if_present):
-            raise IndexError(
-                f"Batch coordinates '{self.batch_dimension}' of input "
-                "variables do not have the same size "
-                "as the batch dimension of the observations."
-            )
+        if bc is not None:
+            matching_batch_coords_if_present = [
+                v[self.batch_dimension] == bc 
+                for k, v in self.coordinates_input_vars.items() 
+                if self.batch_dimension in v
+            ]
+
+            if not all(matching_batch_coords_if_present):
+                raise IndexError(
+                    f"Batch coordinates '{self.batch_dimension}' of input "
+                    "variables do not have the same size "
+                    "as the batch dimension of the observations."
+                )
 
     def solve(self):
         raise NotImplementedError("Solver must implement a solve method.")

--- a/pymob/solvers/base.py
+++ b/pymob/solvers/base.py
@@ -48,6 +48,7 @@ class SolverBase:
                 object.__setattr__(self, key, value)
 
         self.test_matching_batch_dims()
+        self.test_x_coordinates()
         
 
     def __call__(self, **kwargs):
@@ -69,6 +70,22 @@ class SolverBase:
                     "variables do not have the same size "
                     "as the batch dimension of the observations."
                 )
+
+    def test_x_coordinates(self):
+        x = self.coordinates[self.x_dim]
+        if "x_in" not in self.coordinates_input_vars:
+            return
+        
+        x_xin = self.coordinates_input_vars["x_in"][self.x_dim]
+
+        if np.max(x) > np.max(x_xin):
+            raise AssertionError(
+                f"The {self.x_dim}-coordinate on the observations (sim.coordinates) "
+                f"goes to a higher {self.x_dim} than the {self.x_dim}-coordinate "
+                "of the model_parameters['x_in']. "
+                "Make sure to run the simulation only until the provided x_in "
+                "values, or extend the x_in values until the required time"
+            )
 
     def solve(self):
         raise NotImplementedError("Solver must implement a solve method.")

--- a/pymob/solvers/base.py
+++ b/pymob/solvers/base.py
@@ -1,4 +1,5 @@
 import numpy as np
+import xarray as xr
 from typing import Callable, Dict, List, Optional, Sequence, Literal, Tuple
 from frozendict import frozendict
 from dataclasses import dataclass, field
@@ -83,3 +84,61 @@ def mappar(func, parameters, exclude=[], to:Literal["tuple","dict"]="tuple"):
 
     return model_args
 
+
+def create_interpolation(
+        x_in: xr.Dataset, 
+        x: str="time", 
+        factor: float=1e-4, 
+        interpolation: Literal["fill-forward", "linear"] = "fill-forward",
+    ) -> xr.Dataset:
+    """Make the interpolation safe by adding a coordinate just before each 
+    x-value (except the first vaue). The distance between the new and the next
+    point are calculated as a fraction of the previous distance between
+    neighboring points. The corresponding y-values are first set to NaN and then
+    interpolated based on the interpolation method.
+
+    Parameters
+    ----------
+    x_in : xr.Dataset
+        The input dataset which contains a coordinate (x) and a data variable
+        (y)
+    x : str, optional
+        The name of the x coordinate, by default "time"
+    factor : float, optional
+        The distance between the newly added points and the following existing
+        points on the x-scale, by default 1e-4
+    interpolation : Literal["fill-forward", "linear"], optional
+        The interpolation method. In addition to 'fill-forward' and 'linear',
+        any method give in `xr.interpolate_na` can be chosen, by default
+        "fill-forward"
+
+    Returns
+    -------
+    xr.Dataset
+        The interpolated dataset
+    """
+    xs = x_in.coords[x]
+
+    # calculate x values that are located just a little bit smaller than the xs
+    # where "just a little bit" is defined by the distance to the previous x
+    # and a factor. This way the scale of the observations should not matter
+    # and even very differently sized x-steps should be interpolated correctly
+    fraction_before_xs = (
+        xs.isel({x:range(1, len(xs))}).values
+        - xs.diff(dim=x) * factor
+    )
+
+    # create a sorted time vector
+    xs = sorted([*fraction_before_xs.values, *xs.values])
+
+    # add new time indices with NaN values 
+    x_in_reindexed = x_in.reindex({x:xs})
+
+    if interpolation == "fill-forward":
+        # then fill nan values with the previous value (forward-fill)
+        x_in_interpolated = x_in_reindexed.ffill(dim=x, limit=1)
+
+    else:
+        x_in_interpolated = x_in_reindexed.interpolate_na(dim=x, method="linear")
+
+    return x_in_interpolated

--- a/pymob/solvers/diffrax.py
+++ b/pymob/solvers/diffrax.py
@@ -109,8 +109,10 @@ class JaxSolver(SolverBase):
             ]
         else:
             idxs = list(self.indices.values())
-            ode_args_indexed = [jnp.array(a, ndmin=1)[*idxs] for a in ode_args]
-            pp_args_indexed = [jnp.array(a, ndmin=1)[*idxs] for a in pp_args]
+            # this was before used with [*idxs], which threw a syntax error
+            # https://chatgpt.com/c/c5de3adb-3232-4a25-b53d-b63edbb1f4a1
+            ode_args_indexed = [jnp.array(a, ndmin=1)[tuple(idxs)] for a in ode_args]
+            pp_args_indexed = [jnp.array(a, ndmin=1)[tuple(idxs)] for a in pp_args]
             raise RuntimeError("This is not yet implemented, it only looks like it")
 
 

--- a/pymob/solvers/diffrax.py
+++ b/pymob/solvers/diffrax.py
@@ -178,12 +178,15 @@ class JaxSolver(SolverBase):
         term = ODETerm(f)
         solver = self.diffrax_solver()
         saveat = SaveAt(ts=self.x)
+        t_min = self.x[0]
+        t_max = self.x[-1]
+        # jump only those ts that are smaller than the last observations
+        jumps = x_in[0][self.coordinates_input_vars["x_in"][self.x_dim] < self.x[-1]]
         stepsize_controller = PIDController(
             rtol=self.rtol, atol=self.atol,
             pcoeff=self.pcoeff, icoeff=self.icoeff, dcoeff=self.dcoeff, 
+            jump_ts=jumps,
         )
-        t_min = self.x[0]
-        t_max = self.x[-1]
         
         sol = diffeqsolve(
             terms=term, 

--- a/pymob/solvers/diffrax.py
+++ b/pymob/solvers/diffrax.py
@@ -171,9 +171,11 @@ class JaxSolver(SolverBase):
         if len(x_in) > 0:
             interp = LinearInterpolation(ts=x_in[0], ys=x_in[1])
             args=(interp, *args)
+            jumps = x_in[0][self.coordinates_input_vars["x_in"][self.x_dim] < self.x[-1]]
         else:
             interp = None
             args=args
+            jumps = None
 
         term = ODETerm(f)
         solver = self.diffrax_solver()
@@ -181,7 +183,6 @@ class JaxSolver(SolverBase):
         t_min = self.x[0]
         t_max = self.x[-1]
         # jump only those ts that are smaller than the last observations
-        jumps = x_in[0][self.coordinates_input_vars["x_in"][self.x_dim] < self.x[-1]]
         stepsize_controller = PIDController(
             rtol=self.rtol, atol=self.atol,
             pcoeff=self.pcoeff, icoeff=self.icoeff, dcoeff=self.dcoeff, 

--- a/pymob/solvers/diffrax.py
+++ b/pymob/solvers/diffrax.py
@@ -1,0 +1,199 @@
+from functools import partial
+from typing import Optional, List, Dict, Literal
+from pymob.solvers.base import mappar, SolverBase
+from dataclasses import dataclass
+import jax.numpy as jnp
+import jax
+from diffrax import (
+    diffeqsolve, 
+    Dopri5, 
+    Tsit5,
+    Kvaerno5,
+    ODETerm, 
+    SaveAt, 
+    PIDController, 
+    RecursiveCheckpointAdjoint,
+    LinearInterpolation,
+)
+
+Mode = Literal['r', 'rb', 'w', 'wb']
+
+
+@dataclass(frozen=True)
+class JaxSolver(SolverBase):
+    """
+    see https://jax.readthedocs.io/en/latest/faq.html#strategy-3-making-customclass-a-pytree
+    to make thinks robust
+
+    Parameters
+    ----------
+    """
+    batch_dimension: str = "batch_id"
+    x_dim: str = "time"
+    diffrax_solver = Dopri5
+
+    def preprocess_x_in(self, x_in):
+        X_in_list = []
+        for x_in_var, x_in_vals in x_in.items():
+            x_in_dims = x_in_vals["dims"]
+            x_in_coords = {k:v["data"] for k, v in x_in_vals["coords"].items()}
+            x_in_x = jnp.array(x_in_coords[self.x_dim])
+            x_in_y = jnp.array(x_in_vals["data"])
+
+            # broadcast x to y and add a dummy
+            batch_coordinates = x_in_coords.get(self.batch_dimension, [0])
+            n_batch = len(batch_coordinates)
+            X_in_x = jnp.tile(x_in_x, n_batch).reshape((n_batch, *x_in_x.shape))
+
+            # wrap x_in y data in a dummy batch dim if the batch dim is not
+            # included in the coordinates
+            if self.batch_dimension not in x_in_coords:
+                X_in_y = jnp.tile(x_in_y, n_batch)\
+                    .reshape((n_batch, *x_in_y.shape))
+            else:
+                X_in_y = jnp.array(x_in_y)
+
+            # combine xs and ys to make them ready for interpolation
+            X_in = [jnp.array(v) for v in [X_in_x, X_in_y]]
+
+            X_in_list.append(X_in)
+
+        return X_in_list
+    
+    def preprocess_y_0(self, y0):
+        Y0 = []
+        for y0_var, y0_vals in y0.items():
+            y0_dims = y0_vals["dims"]
+            y0_coords = {k:v["data"] for k, v in y0_vals["coords"].items()}
+            y0_data = jnp.array(y0_vals["data"], ndmin=1)
+            
+            # wrap y0 data in a dummy batch dim if the batch dim is not
+            # included in the coordinates
+            if self.batch_dimension not in y0_coords:
+                batch_coordinates = y0_coords.get(self.batch_dimension, [0])
+                n_batch = len(batch_coordinates)
+                y0_batched = jnp.tile(y0_data, n_batch)\
+                    .reshape((n_batch, *y0_data.shape))
+            else:
+                y0_batched = y0_data
+
+            Y0.append(y0_batched)
+        return Y0
+
+    def solve(self, model, post_processing, parameters, coordinates, indices, data_variables, n_ode_states, seed=None):
+        time = tuple(coordinates[self.x_dim])
+        params = parameters["parameters"]
+        x_in = parameters.get("x_in", {})
+        y_0 = parameters.get("y0", {})
+
+        X_in = self.preprocess_x_in(x_in)
+        x_in_flat = [x for xi in X_in for x in xi]
+        Y_0 = self.preprocess_y_0(y_0)
+
+        ode_args = mappar(model, params, exclude=["t", "x_in", "y"])
+        pp_args = mappar(post_processing, params, exclude=["t", "time", "interpolation", "results"])
+        
+        # simply broadcast the parameters along the batch dimension
+        # if there is no other index provided
+        if len(indices) == 0:
+            batch_coordinates = coordinates.get(self.batch_dimension, [0])
+            n_batch = len(batch_coordinates)
+            ode_args_indexed = [
+                jnp.tile(jnp.array(a, ndmin=1), n_batch)\
+                    .reshape((n_batch, *jnp.array(a, ndmin=1).shape))
+                for a in ode_args
+            ]
+            pp_args_indexed = [
+                jnp.tile(jnp.array(a, ndmin=1), n_batch)\
+                    .reshape((n_batch, *jnp.array(a, ndmin=1).shape))
+                for a in pp_args
+            ]
+        else:
+            raise RuntimeError("This is not yet implemented, it only looks like it")
+            idxs = list(indices.values())
+            ode_args_indexed = [jnp.array(a, ndmin=1)[*idxs] for a in ode_args]
+            pp_args_indexed = [jnp.array(a, ndmin=1)[*idxs] for a in pp_args]
+
+
+        initialized_eval_func = partial(
+            odesolve_splitargs,
+            model=model,
+            solver=self.diffrax_solver,
+            post_processing=post_processing,
+            time=time,
+            has_batch_dim=self.batch_dimension in coordinates,
+            odestates = tuple(y_0.keys()),
+            n_odeargs=len(ode_args_indexed),
+            n_ppargs=len(pp_args_indexed),
+            n_xin=len(x_in_flat)
+        )
+        
+        loop_eval = jax.vmap(
+            initialized_eval_func, 
+            in_axes=(
+                *[0 for _ in range(n_ode_states)], 
+                *[0 for _ in range(len(ode_args_indexed))],
+                *[0 for _ in range(len(pp_args_indexed))],
+                *[0 for _ in range(len(x_in_flat))], 
+            )
+        )
+        result = loop_eval(*Y_0, *ode_args_indexed, *pp_args_indexed, *x_in_flat)
+        
+        if self.batch_dimension not in coordinates:    
+            # this is not yet stable, because it may remove extra dimensions
+            # if there is a batch dimension of explicitly one specified
+            result = {v:val.squeeze() for v, val in result.items()}
+
+        return result
+
+
+@partial(jax.jit, static_argnames=["model","solver"])
+def odesolve(model, solver, y0, time, args, x_in):
+    f = lambda t, y, args: model(t, y, *args)
+    
+    if len(x_in) > 0:
+        interp = LinearInterpolation(ts=x_in[0], ys=x_in[1])
+        args=(interp, *args)
+    else:
+        interp = None
+        args=args
+
+    term = ODETerm(f)
+    solver = solver()
+    saveat = SaveAt(ts=time)
+    stepsize_controller = PIDController(rtol=1e-6, atol=1e-7)
+    t_min = jnp.array(time).min()
+    t_max = jnp.array(time).max()
+    
+    sol = diffeqsolve(
+        terms=term, 
+        solver=solver, 
+        t0=t_min, 
+        t1=t_max, 
+        dt0=0.1, 
+        y0=tuple(y0), 
+        args=args, 
+        saveat=saveat, 
+        stepsize_controller=stepsize_controller,
+        adjoint=RecursiveCheckpointAdjoint(),
+        max_steps=10**5,
+        # throw=False returns inf for all t > t_b, where t_b is the time 
+        # at which the solver broke due to reaching max_steps. This behavior
+        # happens instead of throwing an exception.
+        throw=False
+    )
+    
+    return list(sol.ys), interp
+
+@partial(jax.jit, static_argnames=["model", "solver", "post_processing", "time", "odestates", "n_odeargs", "n_ppargs", "n_xin"])
+def odesolve_splitargs(*args, model, solver, post_processing, time, has_batch_dim, odestates, n_odeargs, n_ppargs, n_xin):
+    n_odestates = len(odestates)
+    y0 = args[:n_odestates]
+    odeargs = args[n_odestates:n_odeargs+n_odestates]
+    ppargs = args[n_odeargs+n_odestates:n_odeargs+n_odestates+n_ppargs]
+    x_in = args[n_odestates+n_odeargs+n_ppargs:n_odestates+n_odeargs+n_ppargs+n_xin]
+    sol, interp = odesolve(model=model, solver=solver, y0=y0, time=time, args=odeargs, x_in=x_in)
+    
+    res_dict = {v:val for v, val in zip(odestates, sol)}
+
+    return post_processing(res_dict, jnp.array(time), interp, *ppargs)

--- a/pymob/solvers/diffrax.py
+++ b/pymob/solvers/diffrax.py
@@ -28,6 +28,13 @@ class JaxSolver(SolverBase):
 
     Parameters
     ----------
+
+    throw_exceptions: bool
+        Default is True. The JaxSolver will throw an exception if it runs into a problem
+        with the step size and return infinity. This is done, because likelihood based inference
+        algorithms can deal with infinity values and consider the tested parameter
+        combination impossible. If used without caution, this can lead to severely
+        biased parameter estimates.
     """
 
     extra_attributes = [
@@ -48,7 +55,7 @@ class JaxSolver(SolverBase):
     icoeff = 1.0
     dcoeff = 0.0
     max_steps = int(1e5)
-    throw_exception = False
+    throw_exception = True
 
     @partial(jax.jit, static_argnames=["self"])
     def preprocess_x_in(self, x_in):

--- a/pymob/solvers/diffrax.py
+++ b/pymob/solvers/diffrax.py
@@ -30,7 +30,10 @@ class JaxSolver(SolverBase):
     ----------
     """
 
+    extra_attributes = ["diffrax_solver", "rtol", "atol"]
     diffrax_solver = Dopri5
+    rtol = jnp.float32(1e-6)
+    atol = jnp.float32(1e-7)
 
     @partial(jax.jit, static_argnames=["self"])
     def preprocess_x_in(self, x_in):
@@ -152,7 +155,7 @@ class JaxSolver(SolverBase):
         term = ODETerm(f)
         solver = self.diffrax_solver()
         saveat = SaveAt(ts=self.x)
-        stepsize_controller = PIDController(rtol=1e-6, atol=1e-7)
+        stepsize_controller = PIDController(rtol=self.rtol, atol=self.atol)
         t_min = self.x[0]
         t_max = self.x[-1]
         

--- a/pymob/solvers/diffrax.py
+++ b/pymob/solvers/diffrax.py
@@ -108,10 +108,10 @@ class JaxSolver(SolverBase):
                 for a in pp_args
             ]
         else:
-            raise RuntimeError("This is not yet implemented, it only looks like it")
-            idxs = list(indices.values())
+            idxs = list(self.indices.values())
             ode_args_indexed = [jnp.array(a, ndmin=1)[*idxs] for a in ode_args]
             pp_args_indexed = [jnp.array(a, ndmin=1)[*idxs] for a in pp_args]
+            raise RuntimeError("This is not yet implemented, it only looks like it")
 
 
         initialized_eval_func = partial(

--- a/pymob/solvers/scipy.py
+++ b/pymob/solvers/scipy.py
@@ -1,0 +1,33 @@
+from scipy.integrate import solve_ivp
+
+from pymob.solvers.base import mappar
+
+def solve_ivp_1d(model, parameters, coordinates, data_variables):
+    """Initial value problems always need the same number of recurrent arguments
+
+    - parameters: define the model
+    - y0: set the initial values of the ODE states
+    - coordinates: are needed to know over which values to integrate
+    - seed: In case stochastic processes take place inside the model this is necessary
+    
+    In order to make things explicit, all information which is needed by the
+    model needs to be specified in the function signature. 
+    This also makes the solvers functionally oriented, a feature that helps the
+    usability of models accross inference frameworks. Where functions should not
+    have side effects.
+
+    Additionally, passing arguments via the signature makes it easier to write
+    up models in a casual way and only later embed them into more regulated
+    structures such as pymob
+
+    """
+    odeargs = mappar(model, parameters["parameters"], exclude=["t", "y"])
+    t = coordinates["time"]
+    results = solve_ivp(
+        fun=model,
+        y0=parameters["y0"],
+        t_span=(t[0], t[-1]),
+        t_eval=t,
+        args=odeargs,
+    )
+    return {data_var:y for data_var, y in zip(data_variables, results.y)}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies=[
   "xarray ~= 2023.11.0",
   "sympy ~= 1.12",
   "pydantic ~= 2.5.2",
+  "frozendict ~= 2.3.10",
 ]
 license = {file = "LICENSE"}
 classifiers = [

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -45,10 +45,10 @@ def init_bufferguts_casestudy(scenario="testing"):
     config.case_study.package = "../pollinator-tktd/case_studies"
     config.case_study.simulation = "BuffergutsSimulation"
     config.import_casestudy_modules(reset_path=True)
-    Simulation = config.import_simulation_from_case_study()
-    sim = Simulation(config)
 
-    if hasattr(sim, "_mod"):       
+    if "sim" in config._modules:       
+        Simulation = config.import_simulation_from_case_study()
+        sim = Simulation(config)
         return sim
     else:
         pytest.skip()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -26,7 +26,7 @@ def init_simulation_scripting_api(scenario="test_scenario"):
     config.case_study.scenario = scenario
     config.case_study.package = "case_studies"
     config.case_study.simulation = "Simulation"
-    config.import_casestudy_modules()
+    config.import_casestudy_modules(reset_path=True)
 
     Simulation = config.import_simulation_from_case_study()
     sim = Simulation(config)
@@ -44,8 +44,7 @@ def init_bufferguts_casestudy(scenario="testing"):
     config.case_study.scenario = scenario
     config.case_study.package = "../pollinator-tktd/case_studies"
     config.case_study.simulation = "BuffergutsSimulation"
-    config.import_casestudy_modules()
-
+    config.import_casestudy_modules(reset_path=True)
     Simulation = config.import_simulation_from_case_study()
     sim = Simulation(config)
 
@@ -62,7 +61,7 @@ def init_simulation_scripting_api_v2(scenario="test_scenario"):
     config.case_study.scenario = scenario
     config.case_study.package = "case_studies"
     config.case_study.simulation = "Simulation"
-    config.import_casestudy_modules()
+    config.import_casestudy_modules(reset_path=True)
 
     # and this works as well,
     from test_case_study.sim import Simulation # type: ignore

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,6 +1,7 @@
 import numpy as np
+import pytest
 
-from pymob.sim.config import Config
+from pymob.sim.config import Config, DataVariable, FloatParam
 from pymob.simulation import SimulationBase
 from pymob.utils.store_file import prepare_casestudy
 
@@ -30,6 +31,28 @@ def init_simulation_scripting_api(scenario="test_scenario"):
     Simulation = config.import_simulation_from_case_study()
     sim = Simulation(config)
     sim.setup()
+
+
+
+def init_bufferguts_casestudy(scenario="testing"):
+    """This is an external case study used for local testing. The test study
+    will eventually added also to the remote as an example, but until this happens
+    the test is skipped on the remote.
+    """
+    config = Config()
+    config.case_study.name = "bufferguts"
+    config.case_study.scenario = scenario
+    config.case_study.package = "../pollinator-tktd/case_studies"
+    config.case_study.simulation = "BuffergutsSimulation"
+    config.import_casestudy_modules()
+
+    Simulation = config.import_simulation_from_case_study()
+    sim = Simulation(config)
+
+    if hasattr(sim, "_mod"):       
+        return sim
+    else:
+        pytest.skip()
 
 
 def init_simulation_scripting_api_v2(scenario="test_scenario"):

--- a/tests/test_backend_numpyro.py
+++ b/tests/test_backend_numpyro.py
@@ -221,4 +221,3 @@ if __name__ == "__main__":
     import os
     sys.path.append(os.getcwd())
     # test_user_defined_probability_model()
-    # test_nuts_kernel()

--- a/tests/test_backend_numpyro.py
+++ b/tests/test_backend_numpyro.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 from click.testing import CliRunner
 from matplotlib import pyplot as plt
+from pymob.solvers.diffrax import JaxSolver
 
 from tests.fixtures import init_simulation_casestudy_api
 
@@ -59,6 +60,27 @@ def test_convergence_user_defined_probability_model():
 def test_convergence_nuts_kernel():
     sim = init_simulation_casestudy_api("test_scenario")
 
+    sim.config.inference_numpyro.kernel = "nuts"
+    sim.set_inferer(backend="numpyro")
+    sim.inferer.run()
+    
+    posterior_mean = sim.inferer.idata.posterior.mean( # type: ignore
+        ("chain", "draw"))[sim.model_parameter_names]
+    true_parameters = sim.model_parameter_dict
+    
+    # tests if true parameters are close to recovered parameters from simulated
+    # data
+    np.testing.assert_allclose(
+        posterior_mean.to_dataarray().values,
+        np.array(list(true_parameters.values())),
+        rtol=1e-2, atol=1e-3
+    )
+
+def test_convergence_nuts_kernel_jaxsolver():
+    sim = init_simulation_casestudy_api("test_scenario")
+    sim.solver = JaxSolver
+    sim.dispatch_constructor()
+    
     sim.config.inference_numpyro.kernel = "nuts"
     sim.set_inferer(backend="numpyro")
     sim.inferer.run()

--- a/tests/test_backend_numpyro.py
+++ b/tests/test_backend_numpyro.py
@@ -79,7 +79,9 @@ def test_convergence_nuts_kernel():
 def test_convergence_nuts_kernel_jaxsolver():
     sim = init_simulation_casestudy_api("test_scenario")
     sim.solver = JaxSolver
-    sim.dispatch_constructor()
+    # TODO can the lotka volterra case study be run with the Jax solver
+    # without throw_exception = False
+    sim.dispatch_constructor(throw_exception=False)
     
     sim.config.inference_numpyro.kernel = "nuts"
     sim.set_inferer(backend="numpyro")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ import tempfile
 from pymob.simulation import SimulationBase, Config
 from pymob.sim.config import ArrayParam, FloatParam, DataVariable, Datastructure
 from pymob.utils.store_file import import_package
+from pymob.solvers.scipy import solve_ivp_1d
 import xarray as xr
 import os
 
@@ -50,6 +51,11 @@ def test_simulation():
 
     sim.config.case_study.output = None
 
+    # sim.config.import_casestudy_modules()
+    # sim.load_modules()
+    sim.config.simulation.model = "lotka_volterra"
+
+    sim.solver = solve_ivp_1d
     sim.setup()
     sim.config.save(
         fp=f"{scenario}/test_settings.cfg",

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -4,7 +4,7 @@ import numpy as np
 from click.testing import CliRunner
 
 from pymob.simulation import SimulationBase
-from pymob.sim.config import FloatParam
+from pymob.sim.config import FloatParam, DataVariable
 
 from tests.fixtures import init_simulation_casestudy_api, linear_model
 
@@ -67,7 +67,111 @@ def test_minimal_simulation():
     np.testing.assert_allclose(b, parameters["b"], atol=0.05, rtol=0.05)
     np.testing.assert_allclose(sigma_y, parameters["sigma_y"], atol=0.05, rtol=0.05)
 
+def test_input_parsing():
+    sim = SimulationBase()
+    sim.config.data_structure.A = DataVariable(dimensions=["x", "y"], observed=False)
 
+    sim.config.simulation.y0 = ["X=0"]
+    
+    try:
+        sim.parse_input(input="y0")
+        threw_error = False
+    except KeyError:
+        threw_error = True
+
+    assert threw_error        
+
+
+    sim.config.data_structure.X = DataVariable(dimensions=["x"])
+    test_coordinates = {"x": np.linspace(1, 10, 5), "y": np.array([1, 2])}
+    sim.coordinates = test_coordinates
+    
+    y0 = sim.parse_input(input="y0", drop_dims=[])
+    np.testing.assert_equal(y0.X.values, np.zeros(sim.dimension_sizes["x"]))
+
+    y0 = sim.parse_input(input="y0", drop_dims=["x"])
+    assert float(y0.X.values) == 0.0
+
+
+    sim.config.data_structure.X = DataVariable(dimensions=["y", "x"])
+    y0 = sim.parse_input(input="y0", drop_dims=[])
+    np.testing.assert_equal(y0.X.values, np.zeros((2, 5)))
+
+
+    sim.config.data_structure.X = DataVariable(dimensions=["x", "y"])
+    y0 = sim.parse_input(input="y0", drop_dims=[])
+    np.testing.assert_equal(y0.X.values, np.zeros((5, 2)))
+
+    # test if broadcasting is done correctly
+    sim.config.data_structure.X = DataVariable(dimensions=["x", "y"])
+    sim.config.simulation.y0 = ["X=Array([0, 1])"]
+    y0 = sim.parse_input(input="y0", drop_dims=[])
+    np.testing.assert_equal(y0.X.isel(y=0), np.zeros((5)))
+    np.testing.assert_equal(y0.X.isel(y=1), np.ones((5)))
+
+    # test if broadcasting is done correctly
+    sim.config.data_structure.X = DataVariable(dimensions=["y", "x"])
+    sim.config.simulation.y0 = ["X=Array([0, 1, 2, 3,4])"]
+    y0 = sim.parse_input(input="y0", drop_dims=[])
+    np.testing.assert_equal(y0.X.isel(y=0), np.arange(5))
+    np.testing.assert_equal(y0.X.isel(y=1), np.arange(5))
+
+    # test if broadcasting is done correctly
+    sim.config.data_structure.X = DataVariable(dimensions=["y", "x"])
+    sim.config.simulation.y0 = ["X=Array([[0,1,2,3,4],[1,2,3,4,5]])"]
+    y0 = sim.parse_input(input="y0", drop_dims=[])
+    np.testing.assert_equal(y0.X.isel(y=0), np.arange(5))
+    np.testing.assert_equal(y0.X.isel(y=1), np.arange(1, 6))
+
+    # test if broadcasting is done correctly
+    sim.config.data_structure.X = DataVariable(dimensions=["y", "x"])
+    sim.config.simulation.y0 = ["X=Array([[0,1,2,3,4],[1,2,3,4,5]])"]
+    y0 = sim.parse_input(input="y0", drop_dims=[])
+    np.testing.assert_equal(y0.X.isel(y=0), np.arange(5))
+    np.testing.assert_equal(y0.X.isel(y=1), np.arange(1, 6))
+
+    # test if broadcasting is done correctly
+    sim.config.data_structure.X = DataVariable(dimensions=["y", "x"])
+    sim.config.simulation.y0 = ["X=Array([0, 1])"]
+    y0 = sim.parse_input(input="y0", drop_dims=["x"])
+    np.testing.assert_equal(y0.X.values, np.array([0,1]))
+
+    sim.config.data_structure.X = DataVariable(dimensions=["y", "x"])
+    sim.config.simulation.y0 = ["X=0"]
+    y0 = sim.parse_input(input="y0", drop_dims=["y"])
+    np.testing.assert_equal(y0.X.values, np.array([0,0,0,0,0]))
+
+    sim.config.data_structure.X = DataVariable(dimensions=["y", "x"])
+    sim.config.simulation.y0 = ["X=0"]
+    y0 = sim.parse_input(input="y0", drop_dims=["x","y"])
+    assert float(y0.X.values) == 0.0
+
+    X = xr.DataArray(
+        data=np.random.normal(size=(5,2)), 
+        coords=sim.coordinates
+    ).to_dataset(name="X")
+
+    # test addition of observations when data variables had been specified
+    # before
+    sim.config.data_structure.X = DataVariable(dimensions=["y", "x"])
+    sim.observations = X
+    assert all([np.all(sc == tc) for (sk,sc), (tk,tc) in 
+                zip(sim.coordinates.items(), test_coordinates.items())])
+
+    sim.config.data_structure.remove("X")
+    sim.observations = X
+
+    sim.config.simulation.y0 = ["X=X"]
+    y0 = sim.parse_input(input="y0", reference_data=X.isel(y=0), drop_dims=["y"])
+    np.testing.assert_equal(y0.X.values, X.isel(y=0).X.values)
+    
+    sim.config.simulation.y0 = ["X=2*X"]
+    y0 = sim.parse_input(input="y0", reference_data=X.isel(y=0), drop_dims=["y"])
+    np.testing.assert_equal(y0.X.values, X.isel(y=0).X.values * 2)
+
+    sim.config.simulation.y0 = ["X=exp(X)"]
+    y0 = sim.parse_input(input="y0", reference_data=X.isel(y=0, x=0), drop_dims=["y", "x"])
+    np.testing.assert_equal(y0.X.values, np.exp(X.isel(y=0, x=0).X.values))
 
 def test_indexing_simulation():
     pytest.skip()

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -36,6 +36,8 @@ def test_minimal_simulation():
     sim.config.model_parameters.a = FloatParam(value=10, free=False)
     sim.config.model_parameters.b = FloatParam(value=3, free=True , prior="normal(loc=0,scale=10)")
     sim.model_parameters["parameters"] = sim.config.model_parameters.value_dict
+
+    sim.dispatch_constructor()
     evaluator = sim.dispatch(theta={"b":3})
     evaluator()
     evaluator.results

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,0 +1,27 @@
+import os
+import time
+import pytest
+import numpy as np
+from click.testing import CliRunner
+from pyinstrument import Profiler
+
+from tests.fixtures import init_simulation_casestudy_api
+
+
+def test_benchmark_time():
+    sim = init_simulation_casestudy_api()
+
+    cpu_time_start = time.process_time()
+    sim.benchmark(n=100)
+    cpu_time_stop = time.process_time()
+
+    t = cpu_time_stop - cpu_time_start
+
+    if t > 3:
+        raise AssertionError(f"Benchmarking took too long: {t}s. Expected ~2s")
+
+if __name__ == "__main__":
+    import sys
+    import os
+    sys.path.append(os.getcwd())
+    # test_commandline_API_infer()

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from pymob.solvers.diffrax import JaxSolver
 from pymob.solvers.base import rect_interpolation, radius_interpolation, smoothed_interpolation, jump_interpolation
-from fixtures import init_simulation_casestudy_api, init_bufferguts_casestudy
+from tests.fixtures import init_simulation_casestudy_api, init_bufferguts_casestudy
 from diffrax import Heun, Euler, Tsit5, Dopri5
 
 from pymob.sim.evaluator import Evaluator
@@ -150,5 +150,5 @@ if __name__ == "__main__":
     import sys
     import os
     sys.path.append(os.getcwd())
-    test_rect_interpolation()
+    # test_rect_interpolation()
     # test_benchmark_jaxsolver()

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -19,8 +19,8 @@ def test_benchmark_time():
 
     t = cpu_time_stop - cpu_time_start
 
-    if t > 1:
-        raise AssertionError(f"Benchmarking took too long: {t}s. Expected t < 1s")
+    if t > 2:
+        raise AssertionError(f"Benchmarking took too long: {t}s. Expected t < 2s")
 
 
 def test_benchmark_jaxsolver():

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -3,8 +3,12 @@ import time
 import numpy as np
 
 from pymob.solvers.diffrax import JaxSolver
-from tests.fixtures import init_simulation_casestudy_api
+from pymob.solvers.base import rect_interpolation, radius_interpolation, smoothed_interpolation, jump_interpolation
+from fixtures import init_simulation_casestudy_api, init_bufferguts_casestudy
+from diffrax import Heun, Euler, Tsit5, Dopri5
 
+from pymob.sim.evaluator import Evaluator
+from pymob import SimulationBase
 
 def test_benchmark_time():
     sim = init_simulation_casestudy_api()
@@ -47,8 +51,104 @@ def test_benchmark_jaxsolver():
         raise AssertionError(f"Benchmarking took too long: {t}s. Expected t < 1s")
 
 
+def test_rect_interpolation():
+    sim: SimulationBase
+    sim = init_bufferguts_casestudy(scenario="testing")
+
+    # x input is defined on the interval [0,179]
+    x_in = sim.parse_input(input="x_in", reference_data=sim.observations, drop_dims=[])
+    # rect_interpolation adds duplicates the last y_179 for x_180
+    x_in = rect_interpolation(x_in=x_in, x_dim="time")
+    sim.model_parameters["x_in"] = x_in
+
+    # Interpolations in diffrax now jump each discontinuity until the last time
+    # that is evaluated by the solver. This is not jumped, so that it can be 
+    # retrieved by SaveAt
+    # https://github.com/patrick-kidger/diffrax/issues/58
+    # It seems like this is the intended behavior of diffrax, 
+
+    # run the simulation until exactly the last time, which is a discontinuity
+    # this works and will not return a discontinuity, because jump_ts in the
+    # PIDController of diffrax, is told that it shoud jump all ts that are 
+    # smaller than x_stop
+    sim.coordinates["time"] = np.linspace(0, 179, 1000)
+    sim.dispatch_constructor(max_steps=1e5, throw_exception=True, pcoeff=0.0, icoeff=0.25)
+    e = sim.dispatch(theta={})
+    e()
+
+    # assert that the interpolation produces no infinity values 
+    np.testing.assert_array_equal(
+        (e.results == np.inf).sum().to_array().values, 
+        np.array([0, 0, 0])
+    )
+
+    # test if the simulation also works with the normal time vector
+    sim.reset_coordinate(dim="time")
+    sim.dispatch_constructor(max_steps=1e5, throw_exception=True, pcoeff=0.0, icoeff=0.25)
+    e = sim.dispatch(theta={})
+    e()
+
+    # assert that the interpolation produces no infinity values 
+    np.testing.assert_array_equal(
+        (e.results == np.inf).sum().to_array().values, 
+        np.array([0, 0, 0])
+    )
+
+    # run the simulaton until the added interpolation provided by rect_interpolation
+    # until t=180
+    sim.coordinates["time"] = np.linspace(0, 180, 1000)
+    sim.dispatch_constructor(max_steps=1e5, throw_exception=True, pcoeff=0.0, icoeff=0.25)
+    e = sim.dispatch(theta={})
+    e()
+
+    # assert that the interpolation works without problems if the last specified
+    # value is not a discontinuity
+    np.testing.assert_array_equal(
+        (e.results == np.inf).sum().to_array().values, 
+        np.array([0, 0, 0])
+    )
+
+    # run the simulaton until the added interpolation provided by rect_interpolation
+    # until t=180
+    # This behavior is correctly caught, by pymob, before it can ocurr, because
+    # an interpolation over the provided ts, and ys is not possible. And would
+    # result in a difficult to diagnose max_steps error
+    try:
+        sim.coordinates["time"] = np.linspace(0, 180.01, 1000)
+        sim.dispatch_constructor(max_steps=1e5, throw_exception=True, pcoeff=0.0, icoeff=0.25)
+    except AssertionError:
+        threw_error = True
+
+    if not threw_error: 
+        AssertionError(
+            "The solver should fail if interpolation is attempted "
+            "to be done further than the intended range."        
+        )
+
+def test_no_interpolation():
+    sim: SimulationBase
+    sim = init_bufferguts_casestudy(scenario="testing")
+    
+    # x input is defined on the interval [0,179]
+    x_in = sim.parse_input(input="x_in", reference_data=sim.observations, drop_dims=[])
+
+    # run the simulaton until the provided x_input until t=179
+    sim.coordinates["time"] = np.linspace(0, 179, 1000)
+    sim.dispatch_constructor(max_steps=1e5, throw_exception=True, pcoeff=0.0, icoeff=0.25)
+    e = sim.dispatch(theta={})
+    e()
+
+    # assert that the interpolation works without problems if the last specified
+    # value is not a discontinuity
+    np.testing.assert_array_equal(
+        (e.results == np.inf).sum().to_array().values, 
+        np.array([0, 0, 0])
+    )
+
+
 if __name__ == "__main__":
     import sys
     import os
     sys.path.append(os.getcwd())
+    test_rect_interpolation()
     # test_benchmark_jaxsolver()

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,10 +1,8 @@
 import os
 import time
-import pytest
 import numpy as np
-from click.testing import CliRunner
-from pyinstrument import Profiler
 
+from pymob.solvers.diffrax import JaxSolver
 from tests.fixtures import init_simulation_casestudy_api
 
 
@@ -20,8 +18,36 @@ def test_benchmark_time():
     if t > 3:
         raise AssertionError(f"Benchmarking took too long: {t}s. Expected ~2s")
 
+
+def test_benchmark_jaxsolver():
+    sim = init_simulation_casestudy_api()
+
+    # dispatch is constructed in `init_simulation_case_study`
+    e = sim.dispatch({})
+    e()
+    a = e.results
+
+    # construct the dispatch again with a different solver
+    sim.solver = JaxSolver
+    sim.dispatch_constructor()
+    e = sim.dispatch({})
+    e()
+    b = e.results
+
+    np.testing.assert_allclose(a.to_array(), b.to_array(), atol=1e-3)
+
+    cpu_time_start = time.process_time()
+    sim.benchmark(n=100)
+    cpu_time_stop = time.process_time()
+
+    t = cpu_time_stop - cpu_time_start
+
+    if t > 3:
+        raise AssertionError(f"Benchmarking took too long: {t}s. Expected ~2s")
+
+
 if __name__ == "__main__":
     import sys
     import os
     sys.path.append(os.getcwd())
-    # test_commandline_API_infer()
+    # test_benchmark_jaxsolver()

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -15,8 +15,8 @@ def test_benchmark_time():
 
     t = cpu_time_stop - cpu_time_start
 
-    if t > 3:
-        raise AssertionError(f"Benchmarking took too long: {t}s. Expected ~2s")
+    if t > 1:
+        raise AssertionError(f"Benchmarking took too long: {t}s. Expected t < 1s")
 
 
 def test_benchmark_jaxsolver():
@@ -42,8 +42,8 @@ def test_benchmark_jaxsolver():
 
     t = cpu_time_stop - cpu_time_start
 
-    if t > 3:
-        raise AssertionError(f"Benchmarking took too long: {t}s. Expected ~2s")
+    if t > 1:
+        raise AssertionError(f"Benchmarking took too long: {t}s. Expected t < 1s")
 
 
 if __name__ == "__main__":

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -29,7 +29,8 @@ def test_benchmark_jaxsolver():
 
     # construct the dispatch again with a different solver
     sim.solver = JaxSolver
-    sim.dispatch_constructor()
+    from diffrax import Dopri5
+    sim.dispatch_constructor(diffrax_solver=Dopri5, rtol=1e-6)
     e = sim.dispatch({})
     e()
     b = e.results


### PR DESCRIPTION
This PR contains two major changes:

## New feature: enable variable dimensional input vars `x_in` and `y0`

- `parse_input` has been heavily modified and is now significantly more robust and passes several checks for each input variable. 
- The dimensionality of each input variable is specified in the `DataVariable(dimensions=[...])` API and therefore allows individual dimensions for each variable
- `DataVariable` has an additional attribute `observed`, which specifies whether a variable is found in the data or not. By default these are set to True, in order to raise errors, and notify the user about the intended behaviour
- add the option to remove data variables with `config.data_structure.remove(key)`
- add various properties for `config.data_structure`
- add more checks in `observations` and `coordinates` setters
- refactor `set_coordinates` and `create_coordinates` (no effects on the exposed API, but internally more consistent)
- add multiple tests for input parsing
- Warning. Currently, the API supports differently ordered dimensions in the x_in and y0 variable, but this is not supported further downstream of the pipeline. Eventually all data_Variables should have the same dimensional order (excluding absent dims). This will be adressed in #76 

## API Change: Evaluator dispatch

- Dispatch API was refactored, based on #36, because the `Evaluator` was repeatedly rebuilt, which significantly increased the workload by unnecessary calls.
- The Evaluator now constructs a solver, which takes on many initialization tasks, that are only needed when _static_ arguments of the simulation (coordinates, data_variables, dimensions, post_processing, model, solver) change. In practice it is recommended to call `dispatch_constructor(...)` just before an evaluation or inference is started.
- The solver itself can be a function, a staticmethod or (and preferred) a SolverBase class, which is a frozen `dataclass`. This has the advantage, that frozen dataclasses are suitable objects for use with jax and diffrax, because they support automated hash generation. A hashable solver class can then be passed as a static argument in jitted functions along the lines of https://jax.readthedocs.io/en/latest/faq.html#strategy-2-marking-self-as-static. This makes the a frozen solver class, fully jitted, significantly contributing to speedup. :rocket: :rocket:
- With this change also a `JaxSolver` and some additional solvers (scipy, analytic) are provided in the `pymob.solvers` package. This change makes the creation of new and fast simulations very simple.
- `sim.dispatch(theta=...)` remains unchanged, but instead of initializing the evaluator it simply deepcopies it and passes the `model_parameters` dictionary to the evaluator. 
- Instead the `Evaluator` is now constructed in the `dispatch_constructor`, which takes additional keyword arguments that are solver specific.
- The new API passes all tests, but is currently still considered very experimental. With the next few patch releases, bug fixes and some minor changes can be expected.

