### PR TITLE
fix multichain numpyro idata bug

### DIFF
--- a/pymob/inference/numpyro_backend.py
+++ b/pymob/inference/numpyro_backend.py
@@ -1093,7 +1093,8 @@ class NumpyroBackend(InferenceBackend):
             prior_predictive=obs_predictions,
             observed_data=obs,
             log_likelihood=log_likelihood,
-            n_draws=n
+            n_draws=n,
+            n_chains=1
         )
     
 
@@ -1106,6 +1107,7 @@ class NumpyroBackend(InferenceBackend):
         posterior_predictive: Dict[str, NumericArray] = {},
         observed_data: Dict[str, NumericArray] = {},
         n_draws: Optional[int] = None,
+        n_chains: Optional[int] = None,
         **kwargs,
     ):
         """Create an Arviz idata object from samples.
@@ -1115,6 +1117,9 @@ class NumpyroBackend(InferenceBackend):
         # posterior_coords["chain"] = [0]
         if n_draws is not None:
             posterior_coords["draw"] = list(range(n_draws))
+
+        if n_chains is not None:
+            posterior_coords["chain"] = list(range(n_chains))
         data_structure = self.posterior_data_structure
 
         data_variables = self.config.data_structure.data_variables

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -73,6 +73,48 @@ def test_prior_predictions():
     np.testing.assert_array_equal(idata.prior.coords["experiment"], sim.dimension_coords["experiment"])
 
 
+
+def test_prior_predictions_nuts():
+    sim = init_lotka_volterra_case_study_hierarchical_from_settings("lotka_volterra_hierarchical_presimulated_v1")
+    sim.solver = JaxSolver
+
+    sim.config.inference.n_predictions = 30
+    sim.config.inference_numpyro.chains = 2
+    sim.config.inference_numpyro.draws = 5
+    sim.config.inference_numpyro.nuts_max_tree_depth = 1
+    sim.config.inference_numpyro.gaussian_base_distribution = True
+    sim.config.inference_numpyro.kernel = "nuts"
+
+    sim.dispatch_constructor()
+    sim.set_inferer(backend="numpyro")
+
+    idata = sim.inferer.prior_predictions(n=5)
+
+    np.testing.assert_equal(
+        list(idata.prior.data_vars.keys()),
+        ["alpha", "alpha_sigma", "alpha_species", "alpha_species_hyper", "beta"]
+    )
+    
+    np.testing.assert_equal(
+        list(idata.prior_predictive.data_vars.keys()),
+        ["rabbits", "wolves"]
+    )
+
+    np.testing.assert_equal(
+        list(idata.prior_model_fits.data_vars.keys()),
+        ["rabbits", "wolves"]
+    )
+
+    np.testing.assert_equal(
+        list(idata.prior_residuals.data_vars.keys()),
+        ["rabbits", "wolves"]
+    )
+
+    np.testing.assert_array_equal(idata.prior.coords["id"], sim.observations["id"])
+    np.testing.assert_array_equal(idata.prior.coords["rabbit_species"], sim.dimension_coords["rabbit_species"])
+    np.testing.assert_array_equal(idata.prior.coords["experiment"], sim.dimension_coords["experiment"])
+
+
 def test_posterior_predictions_nuts():
     sim = init_simulation_casestudy_api("test_scenario")
     sim.solver = JaxSolver
@@ -83,11 +125,11 @@ def test_posterior_predictions_nuts():
     sim.config.inference_numpyro.warmup = 0
     sim.config.inference_numpyro.nuts_max_tree_depth = 1
     sim.config.inference_numpyro.gaussian_base_distribution = True
+    sim.config.inference_numpyro.kernel = "nuts"
 
     sim.dispatch_constructor()
     sim.set_inferer(backend="numpyro")
 
-    sim.config.inference_numpyro.kernel = "nuts"
     sim.inferer.run()
     idata = sim.inferer.idata
 


### PR DESCRIPTION
Fix number of chains in prior predictions at one in .to_arviz_data()  and and add a corresponding test

This ensures that prior predictions can be parsed to idata objects with a NUTS kernel