### PR TITLE
Implement a draft for utilizing the evaluator framework for UDEs

### DIFF
--- a/pymob/__init__.py
+++ b/pymob/__init__.py
@@ -3,6 +3,7 @@ from . import sim
 from . import utils
 from . import solvers
 from . import examples
+from . import model
 
 __version__ = "0.6.4"
 

--- a/pymob/model/__init__.py
+++ b/pymob/model/__init__.py
@@ -1,0 +1,1 @@
+from . import base

--- a/pymob/model/base.py
+++ b/pymob/model/base.py
@@ -1,0 +1,14 @@
+import types
+from typing import Any
+
+class Model:
+    """This should be extended into a template for model definitions"""
+    exclude_model_kwargs = ("t", "y", "x_in")
+
+
+    def __call__(self, t, y, x_in, *args, **kwargs) -> Any:
+        return self.model(t, y, x_in, *args, **kwargs)
+
+    @staticmethod
+    def model(t, y, x_in):
+        raise NotImplementedError

--- a/pymob/sim/evaluator.py
+++ b/pymob/sim/evaluator.py
@@ -1,3 +1,4 @@
+import types
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 import inspect
 from frozendict import frozendict
@@ -6,7 +7,8 @@ import xarray as xr
 import numpy as np
 from numpy.typing import NDArray
 from pymob.solvers.base import mappar, SolverBase
-from pymob.utils.errors import import_optional_dependency
+from pymob.model.base import Model
+
 
 def create_dataset_from_numpy(Y, Y_names, coordinates):
     DeprecationWarning(
@@ -83,7 +85,7 @@ class Evaluator:
 
     def __init__(
             self,
-            model: Callable,
+            model: types.FunctionType|types.MethodType|Model,
             solver: type|Callable,
             dimensions: Sequence[str],
             dimension_sizes: Dict[str, int],
@@ -157,11 +159,13 @@ class Evaluator:
         self.batch_dimension = batch_dimension
         self.solver_options = solver_options
         
-
-        
+        if isinstance(model, (types.FunctionType, types.MethodType)):
+            model_equations = model
+        else:
+            model_equations = model.model
 
         self.parameter_dims = self._regularize_batch_dimensions(
-            arg_names=list(mappar(model, {}, to="names")) + list(mappar(post_processing, {}, to="names")), # type: ignore
+            arg_names=list(mappar(model_equations, {}, to="names")) + list(mappar(post_processing, {}, to="names")), # type: ignore
             arg_dims=parameter_dims
         )
 
@@ -186,6 +190,7 @@ class Evaluator:
         _ = [setattr(self, key, val) for key, val in kwargs.items()]
 
         self._signature = {}
+
 
         if callable(model):
             if hasattr(model, "__func__"):
@@ -241,15 +246,6 @@ class Evaluator:
                 solver_options.update(solver_extra_options)
 
                 model_solver = self.model
-
-                equinox = import_optional_dependency(
-                    "equinox", errors="ignore"
-                )
-                if equinox is not None:
-                    from pymob.solvers.diffrax import UDESolver
-                    import equinox as eqx
-                    if solver == UDESolver:
-                        model_params, model_solver = eqx.partition(self.model, eqx.is_array)             
 
                 self._solver = solver(
                     model=model_solver,
@@ -358,20 +354,7 @@ class Evaluator:
         if seed is not None:
             self._signature.update({"seed": seed})
 
-        equinox = import_optional_dependency(
-            "equinox", errors="ignore"
-        )
-        if equinox is not None:
-            from pymob.solvers.diffrax import UDESolver
-            import equinox as eqx
-            if isinstance(self._solver, UDESolver):
-                params, static = eqx.partition(self.model, eqx.is_array)
-                Y_ = self._solver(params, **self.parameters)
-            elif isinstance(self._solver, SolverBase):
-                Y_ = self._solver(**self.parameters)
-            else:
-                Y_  = self._solver(parameters=self.parameters, **self._signature)
-        elif isinstance(self._solver, SolverBase):
+        if isinstance(self._solver, SolverBase):
             Y_ = self._solver(**self.parameters)
         else:
             Y_ = self._solver(parameters=self.parameters, **self._signature)

--- a/pymob/simulation.py
+++ b/pymob/simulation.py
@@ -5,6 +5,8 @@ import warnings
 import textwrap
 import tempfile
 import importlib
+import types
+
 from copy import deepcopy
 from typing import Optional, List, Union, Literal, Any, Tuple, Sequence, Mapping, TypeVar
 from types import ModuleType
@@ -32,6 +34,8 @@ from pymob.sim.config import ParameterDict, DataVariable, Param, NumericArray, C
 from pymob.sim.plot import SimulationPlot
 from pymob.sim.report import Report
 from pymob.solvers.diffrax import UDESolver
+from pymob.model.base import Model
+
 
 config_deprecation = "Direct access of config options will be deprecated. Use `Simulation.config.OPTION` API instead"
 MODULES = ["sim", "mod", "prob", "data", "plot"]
@@ -195,7 +199,7 @@ class SimulationBase:
     """
     Report = Report
     SimulationPlot = SimulationPlot
-    model: Optional[Callable] = None
+    _model: Optional[Model] = None
     solver: Optional[Callable] = None
     solver_post_processing: Optional[Callable] = None
     _mod: ModuleType
@@ -274,6 +278,30 @@ class SimulationBase:
             model_parameters=copy.deepcopy(dict(self.model_parameters))
         )
         self.dispatch_constructor()
+
+
+    @property
+    def model(self):
+        return self._model
+    
+    @model.setter
+    def model(self, value):
+        if isinstance(value, (types.FunctionType, types.MethodType)):
+            warnings.warn(
+                "Use pymob.model.base.Model class instead of pure functions or methods " +
+                "For defining models.", category=DeprecationWarning
+            )
+                
+            _model = Model()
+            _model.model = value
+        elif isinstance(value, Model):
+            _model = value
+        else:
+            raise NotImplementedError("model must be function, method or Model type")
+
+        assert hasattr(_model, "model")
+
+        self._model = _model
 
     @property
     def model_parameters(self) -> Dict[Literal["parameters","y0","x_in"],Any]:
@@ -718,33 +746,21 @@ class SimulationBase:
         
     def infer_ode_states(self) -> int:
         if self.config.simulation.n_ode_states == -1:
-            try: 
-                equinox = import_optional_dependency(
-                    "equinox", errors="ignore"
-                )
-                if equinox is not None:
-                    from pymob.solvers.diffrax import UDESolver
-                    if self.solver == UDESolver:
-                        return_args = get_return_arguments(self.model.model)
-                    else:
-                        return_args = get_return_arguments(self.model)
-                else:
-                    return_args = get_return_arguments(self.model)
-                n_ode_states = len(return_args)
-                warnings.warn(
-                    "The number of ODE states was not specified in "
-                    "the config file [simulation] > 'n_ode_states = <n>'. "
-                    f"Extracted the return arguments {return_args} from the "
-                    "source code. "
-                    f"Setting 'n_ode_states={n_ode_states}."
-                )
-            except:  # noqa: E722
-                warnings.warn(
-                    "The number of ODE states was not specified in "
-                    "the config file [simulation] > 'n_ode_states = <n>' "
-                    "and could not be extracted from the return arguments."
-                )
-                n_ode_states = -1
+            if isinstance(self.model, (types.FunctionType, types.MethodType)):
+                return_args = get_return_arguments(self.model)
+            elif isinstance(self.model, Model):
+                return_args = get_return_arguments(self.model.model)
+            else:
+                raise NotImplementedError("model must be function, method or Model")
+
+            n_ode_states = len(return_args)
+            warnings.warn(
+                "The number of ODE states was not specified in "
+                "the config file [simulation] > 'n_ode_states = <n>'. "
+                f"Extracted the return arguments {return_args} from the "
+                "source code. "
+                f"Setting 'n_ode_states={n_ode_states}."
+            )
         else:
             n_ode_states = self.config.simulation.n_ode_states
 
@@ -860,6 +876,7 @@ class SimulationBase:
                 )
         else:
             model = self.model
+
 
         self.n_ode_states = self.infer_ode_states()
 

--- a/pymob/solvers/base.py
+++ b/pymob/solvers/base.py
@@ -1,7 +1,7 @@
 import numpy
 import numpy as np
 from numpy.typing import ArrayLike
-from types import ModuleType
+from types import ModuleType, FunctionType, MethodType
 import xarray as xr
 from typing import (
     Callable, Dict, List, Optional, Sequence, Literal, Tuple, Union
@@ -12,6 +12,7 @@ import inspect
 from scipy.ndimage import gaussian_filter1d
 from diffrax import rectilinear_interpolation
 from pymob.utils.errors import PymobError
+from pymob.model.base import Model
 
 @dataclass(frozen=True)
 class SolverBase:
@@ -20,7 +21,7 @@ class SolverBase:
     to pass on important arguments of the simulation relevant to the 
     Solver. Therefore a solver can access all attributes of an Evaluator
     """
-    model: Callable
+    model: Model|FunctionType|MethodType
     dimensions: Tuple
     dimension_sizes: frozendict[str, int]
     parameter_dims: frozendict[str, Tuple[str, ...]]
@@ -240,10 +241,17 @@ class SolverBase:
             )
 
     def preprocess_parameters(self, parameters, num_backend: ModuleType=numpy):
+        if isinstance(self.model, (FunctionType, MethodType)):
+            _exclude_kwargs_model = self.exclude_kwargs_model
+            _model = self.model
+        else:
+            _exclude_kwargs_model = tuple(set([*self.exclude_kwargs_model, *self.model.exclude_model_kwargs])) 
+            _model = self.model.model
+
         ode_args = mappar(
-            self.model, 
+            _model, 
             parameters, 
-            exclude=self.exclude_kwargs_model, 
+            exclude=_exclude_kwargs_model, 
             to="dict"
         )
         ode_args_broadcasted = self._broadcast_args(

--- a/pymob/utils/UDE.py
+++ b/pymob/utils/UDE.py
@@ -3,7 +3,7 @@ import jax.numpy as jnp
 import jax.tree_util as jtu
 import jax.nn as jnn
 import jax.lax as jl
-from typing import Callable
+from typing import Any, Callable
 from pymob.utils.errors import import_optional_dependency
 equinox = import_optional_dependency(
     "equinox", errors="raise", extra="set_inferer(backend='equinox') was not executed successfully, because "
@@ -387,7 +387,11 @@ class UDEBase(eqx.Module):
         else:
             res = jnp.array(derivatives)
             return res.reshape((res.shape[0]))
-        
+
+    @staticmethod
+    def model(t, y, x_in, *args, **kwargs):
+        raise NotImplementedError
+
     @staticmethod
     def loss(y_obs, y_pred):
         '''
@@ -426,3 +430,33 @@ class UDEBase(eqx.Module):
     
     def __eq__(self, other):
         return type(self) == type(other) and self.__hash__() == other.__hash__()
+    
+
+from pymob.model.base import Model
+
+# TODO: UDE.py Should be moved to pymob.model.ude.py
+
+class UDEModel(Model):
+    """Thin wrapper around UDEBase to obtain standard model evaluation logic with pytrees,
+    that cannot have mutable attributes. In the evaluator, the UDEModel is created
+    from the defined UDE
+    """
+    exclude_model_kwargs = ("t", "y", "x_in", "mlp")
+
+    def __call__(self, t, y, x_in, *args, **kwargs) -> Any:
+        # implement logic to convert theta into a pytree compatible with the static ude model
+        # theta is a dictionary of model parameters, where one key should be the biases
+        # and another key are the weights, the remaining keys are the non-NN model parameters
+        # ...
+
+        # combine the static pytree with the parameters
+        eqx.combine(self.ude, )
+        self.ude()
+
+        # implement logic to obtain the output of the pytree
+
+    def __init__(self, ude: UDEBase) -> None:
+        # this is required for consistency purposes
+        self.model = ude.model
+        _, static_ude_model = eqx.partition(ude, filter_spec=eqx.is_array)
+        self.ude = static_ude_model

--- a/pymob/utils/__init__.py
+++ b/pymob/utils/__init__.py
@@ -3,3 +3,4 @@ from . import math_helpers
 from . import misc
 from . import errors
 from . import testing
+from . import UDE

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -169,18 +169,21 @@ def create_simulation_for_test_numpyro_behavior():
     sim.config.save(force=True)
     
 def init_lotka_volterra_UDE_case_study_from_settings(option: str):
-    from lotka_volterra_UDE_case_study.mod import Func
+    from lotka_volterra_case_study.mod import Func
+    from pymob.utils.UDE import UDEModel
 
-    config = Config(f"case_studies/lotka_volterra_UDE_case_study/scenarios/{option}/settings.cfg")
+    config = Config(f"case_studies/lotka_volterra_case_study/scenarios/{option}/settings.cfg")
+
     sim = SimulationBase(config)
     sim.initialize(config)
 
     key = jr.PRNGKey(5678)
     data_key, model_key, loader_key = jr.split(key, 3)
-    sim.model = Func({"alpha":jnp.array(1.3), "delta":jnp.array(1.8)},key=model_key)
 
-    sim.solver = UDESolver
+    ude = Func({"alpha":jnp.array(1.3), "delta":jnp.array(1.8)},key=model_key)
 
-    sim.model_parameters["y0"] = sim.observations.sel(time = 0).drop_vars("time")
+    sim.model = UDEModel(ude=ude)
+
+    sim.solver = JaxSolver
 
     return sim

--- a/tests/test_backend_optax.py
+++ b/tests/test_backend_optax.py
@@ -2,7 +2,7 @@ import numpy as np
 from tests.fixtures import init_lotka_volterra_UDE_case_study_from_settings
 
 # def test_convergence_optax_backend():
-#     sim = init_lotka_volterra_UDE_case_study_from_settings("InfererTest")
+#     sim = init_lotka_volterra_UDE_case_study_from_settings("test_scenario_v2")
 
 #     sim.dispatch_constructor()
 
@@ -23,3 +23,15 @@ from tests.fixtures import init_lotka_volterra_UDE_case_study_from_settings
 
 #     obs_predator = np.where(np.isnan(sim.observations.predator.values), evaluator.Y["predator"], sim.observations.predator.values)
 #     np.testing.assert_allclose(evaluator.Y["predator"], obs_predator, atol = 1, rtol = 1)
+
+def test_ude_solve_with_evaluator():
+    sim = init_lotka_volterra_UDE_case_study_from_settings("test_scenario_v2")
+
+    sim.dispatch_constructor()
+
+    sim.model
+    sim.solver
+
+    e = sim.dispatch()
+
+    e()


### PR DESCRIPTION
+ Implement a basic Model class, which is used for models in pymob.
+ Implement a model property, which converts functions or methods to Model instances, when they are used in scripting mode
+ Continue to support function/method mdoels, but raise a deprecation warning
+ remove optional equinox imports, because they are no longer necessary, when UDEBase models are wrapped in the UDEModel class (see fixtures for usage)
+ implement test_ude_solve_with_evaluator